### PR TITLE
#33 Added crud operations for reviews

### DIFF
--- a/API/Controllers/ReviewsController.cs
+++ b/API/Controllers/ReviewsController.cs
@@ -1,0 +1,121 @@
+﻿using API.Dtos;
+using API.Entities;
+using API.Interfaces;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ReviewsController : ControllerBase
+    {
+        private readonly IReviewsRepository _repo;
+        private readonly UserManager<User> _userManager;
+        private readonly IMapper _mapper;
+
+        public ReviewsController(IReviewsRepository repo, UserManager<User> userManager, IMapper mapper)
+        {
+            _repo = repo;
+            _userManager = userManager;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IReadOnlyList<ReviewReturnDto>>> GetReviews()
+        {
+            var reviewsFromDb = await _repo.GetReviewsAsync();
+
+            var data = _mapper.Map<IReadOnlyList<ReviewReturnDto>>(reviewsFromDb);
+
+            return Ok(data);
+        }
+
+        [HttpGet("book/{bookId}")]
+        public async Task<ActionResult<IReadOnlyList<ReviewReturnDto>>> GetReviewsForBook(int bookId)
+        {
+            var reviewsFromDb = await _repo.GetReviewsByBookIdAsync(bookId);
+
+            var data = _mapper.Map<IReadOnlyList<ReviewReturnDto>>(reviewsFromDb);
+
+            return Ok(data);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ReviewReturnDto>> GetReviewById(int id)
+        {
+            var reviewFromDb = await _repo.GetReviewByIdAsync(id);
+
+            var data = _mapper.Map<ReviewReturnDto>(reviewFromDb);
+
+            return Ok(data);
+        }
+
+        [Authorize]
+        [HttpPost]
+        public async Task<ActionResult<ReviewReturnDto>> AddReview(ReviewAddDto reviewToAdd)
+        {
+            var email = User.FindFirstValue(ClaimTypes.Email);
+
+            var user = await _userManager.FindByEmailAsync(email);
+
+            var review = _mapper.Map<Review>(reviewToAdd);
+
+            review.AddedAt = DateTime.Now;
+            review.UserId = user.Id;
+
+            var addedReview = await _repo.AddReviewAsync(review);
+
+            var reviewToReturn = _mapper.Map<ReviewReturnDto>(addedReview);
+
+            return CreatedAtAction(nameof(GetReviewById), new { id = reviewToReturn.Id }, reviewToReturn);
+        }
+
+        [Authorize]
+        [HttpPut]
+        public async Task<ActionResult<ReviewReturnDto>> UpdateAuthor(ReviewUpdateDto reviewToUpdate)
+        {
+            var review = await _repo.GetReviewByIdAsync(reviewToUpdate.Id);
+
+            if (review == null) return NotFound();
+
+            var email = User.FindFirstValue(ClaimTypes.Email);
+
+            var user = await _userManager.FindByEmailAsync(email);
+
+            if (user.Id != review.UserId) return Unauthorized();
+
+            review.GivenRate = reviewToUpdate.GivenRate;
+            review.Content = reviewToUpdate.Content;
+
+            await _repo.UpdateReviewAsync(review);
+
+            return NoContent();
+        }
+
+        [Authorize]
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteReview(int id)
+        {
+            var review = await _repo.GetReviewByIdAsync(id);
+
+            if (review == null) return NotFound();
+
+            var email = User.FindFirstValue(ClaimTypes.Email);
+
+            var user = await _userManager.FindByEmailAsync(email);
+
+            if (user.Id != review.UserId) return Unauthorized();
+
+            await _repo.DeleteReviewAsync(review);
+
+            return NoContent();
+        }
+    }
+}

--- a/API/Data/Migrations/20210508101719_AddedFieldAddedAtToReviews.Designer.cs
+++ b/API/Data/Migrations/20210508101719_AddedFieldAddedAtToReviews.Designer.cs
@@ -4,14 +4,16 @@ using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210508101719_AddedFieldAddedAtToReviews")]
+    partial class AddedFieldAddedAtToReviews
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210508101719_AddedFieldAddedAtToReviews.cs
+++ b/API/Data/Migrations/20210508101719_AddedFieldAddedAtToReviews.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class AddedFieldAddedAtToReviews : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AddedAt",
+                table: "Reviews",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AddedAt",
+                table: "Reviews");
+        }
+    }
+}

--- a/API/Data/ReviewsRepository.cs
+++ b/API/Data/ReviewsRepository.cs
@@ -1,0 +1,61 @@
+﻿using API.Entities;
+using API.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace API.Data
+{
+    public class ReviewsRepository : IReviewsRepository
+    {
+        private readonly AppDbContext _context;
+
+        public ReviewsRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Review> AddReviewAsync(Review review)
+        {
+            _context.Reviews.Add(review);
+            await _context.SaveChangesAsync();
+
+            return review;
+        }
+
+        public async Task DeleteReviewAsync(Review review)
+        {
+            _context.Reviews.Remove(review);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<Review> GetReviewByIdAsync(int id)
+        {
+            return await _context.Reviews.FindAsync(id);
+        }
+
+        public async Task<IReadOnlyList<Review>> GetReviewsAsync()
+        {
+            return await _context.Reviews
+                .OrderByDescending(x => x.AddedAt)
+                .ToListAsync();
+        }
+
+        public async Task<IReadOnlyList<Review>> GetReviewsByBookIdAsync(int bookId)
+        {
+            return await _context.Reviews
+                .Where(x => x.BookId == bookId)
+                .OrderByDescending(x => x.AddedAt)
+                .ToListAsync();
+        }
+
+        public async Task<Review> UpdateReviewAsync(Review review)
+        {
+            _context.Entry(review).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+
+            return review;
+        }
+    }
+}

--- a/API/Dtos/ReviewAddDto.cs
+++ b/API/Dtos/ReviewAddDto.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace API.Dtos
+{
+    public class ReviewAddDto
+    {
+        [Required]
+        [Range(0, 10)]
+        public double GivenRate { get; set; }
+
+        [Required]
+        public string Content { get; set; }
+
+        [Required]
+        public int BookId { get; set; }
+    }
+}

--- a/API/Dtos/ReviewReturnDto.cs
+++ b/API/Dtos/ReviewReturnDto.cs
@@ -1,0 +1,11 @@
+﻿namespace API.Dtos
+{
+    public class ReviewReturnDto
+    {
+        public int Id { get; set; }
+        public double GivenRate { get; set; }
+        public string Content { get; set; }
+        public string AddedAt { get; set; }
+        public int BookId { get; set; }
+    }
+}

--- a/API/Dtos/ReviewUpdateDto.cs
+++ b/API/Dtos/ReviewUpdateDto.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace API.Dtos
+{
+    public class ReviewUpdateDto
+    {
+        [Required]
+        public int Id { get; set; }
+
+        [Required]
+        [Range(0, 10)]
+        public double GivenRate { get; set; }
+
+        [Required]
+        public string Content { get; set; }
+    }
+}

--- a/API/Entities/Review.cs
+++ b/API/Entities/Review.cs
@@ -1,10 +1,13 @@
-﻿namespace API.Entities
+﻿using System;
+
+namespace API.Entities
 {
     public class Review
     {
         public int Id { get; set; }
         public double GivenRate { get; set; }
         public string Content { get; set; }
+        public DateTime AddedAt { get; set; }
         public int BookId { get; set; }
         public Book Book { get; set; }
         public string UserId { get; set; }

--- a/API/Helpers/MappingProfiles.cs
+++ b/API/Helpers/MappingProfiles.cs
@@ -1,6 +1,7 @@
 ﻿using API.Dtos;
 using API.Entities;
 using AutoMapper;
+using System;
 
 namespace API.Helpers
 {
@@ -46,7 +47,11 @@ namespace API.Helpers
                 .ForMember(
                     dest => dest.Url,
                     opt => opt.MapFrom<AvatarUrlResolver>());
-
+            CreateMap<ReviewAddDto, Review>()
+                .ForMember(
+                    dest => dest.GivenRate,
+                    opt => opt.MapFrom(src => Math.Round(src.GivenRate, 1)));
+            CreateMap<Review, ReviewReturnDto>();
         }
     }
 }

--- a/API/Interfaces/IReviewsRepository.cs
+++ b/API/Interfaces/IReviewsRepository.cs
@@ -1,0 +1,16 @@
+﻿using API.Entities;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace API.Interfaces
+{
+    public interface IReviewsRepository
+    {
+        Task<Review> GetReviewByIdAsync(int id);
+        Task<IReadOnlyList<Review>> GetReviewsByBookIdAsync(int bookId);
+        Task<IReadOnlyList<Review>> GetReviewsAsync();
+        Task<Review> AddReviewAsync(Review review);
+        Task<Review> UpdateReviewAsync(Review review);
+        Task DeleteReviewAsync(Review review);
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -33,6 +33,8 @@ namespace API
 
             services.AddScoped<IAuthorsRepository, AuthorsRepository>();
 
+            services.AddScoped<IReviewsRepository, ReviewsRepository>();
+
             services.AddScoped<IVirtualLibrariesRepository, VirtualLibrariesRepository>();
 
             services.AddScoped<ITokenService, TokenService>();


### PR DESCRIPTION
Actions available:

- get all reviews
- get all reviews for the exact book
- add review
- update review
- delete review

Additionally, the "AddedAt" timestamp was added to review entity.

Reviews returned on GET are by default sorted descending by AddedAt.

To perform adding/updating/deleting authorization is required.